### PR TITLE
Add Base Entity, Service and Tests

### DIFF
--- a/src/main/java/com/seals/camplanner/commons/models/AuditableEntity.java
+++ b/src/main/java/com/seals/camplanner/commons/models/AuditableEntity.java
@@ -1,0 +1,30 @@
+package com.seals.camplanner.commons.models;
+
+import java.sql.Timestamp;
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Entity class with audit information.
+ * TODO This needs user context before it can be implemented.
+ */
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@MappedSuperclass
+public abstract class AuditableEntity extends BaseEntity {
+
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private Long createdBy;
+
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private Timestamp createdDate;
+
+    @Column(name = "last_modified_by", nullable = false)
+    private Long lastModifiedBy;
+
+    @Column(name = "last_modified_date", nullable = false)
+    private Timestamp lastModifiedDate;
+}

--- a/src/main/java/com/seals/camplanner/commons/models/BaseEntity.java
+++ b/src/main/java/com/seals/camplanner/commons/models/BaseEntity.java
@@ -1,0 +1,18 @@
+package com.seals.camplanner.commons.models;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import lombok.Data;
+
+@Data
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+}

--- a/src/main/java/com/seals/camplanner/commons/services/BaseService.java
+++ b/src/main/java/com/seals/camplanner/commons/services/BaseService.java
@@ -1,0 +1,42 @@
+package com.seals.camplanner.commons.services;
+
+import com.seals.camplanner.commons.models.BaseEntity;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public abstract class BaseService<T extends BaseEntity> implements IBaseService<T> {
+
+    protected abstract JpaRepository<T, Long> getRepository();
+
+    public abstract String getEntityName();
+
+    @Override
+    public T findById(Long id) {
+        return this.getRepository()
+                   .findById(id)
+                   .orElseThrow(() -> new NoSuchElementException(
+                           String.format("Unable to find %s with supplied id", this.getEntityName())
+                   ));
+    }
+
+    @Override
+    public List<T> findAll() {
+        return this.getRepository().findAll();
+    }
+
+    @Override
+    public T save(T entity) {
+        return this.getRepository().save(entity);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        this.getRepository().deleteById(id);
+    }
+
+    @Override
+    public void deleteAll() {
+        this.getRepository().deleteAll();
+    }
+}

--- a/src/main/java/com/seals/camplanner/commons/services/IBaseService.java
+++ b/src/main/java/com/seals/camplanner/commons/services/IBaseService.java
@@ -1,0 +1,18 @@
+package com.seals.camplanner.commons.services;
+
+import com.seals.camplanner.commons.models.BaseEntity;
+import java.util.List;
+
+public interface IBaseService<T extends BaseEntity> {
+
+    T findById(Long id);
+
+    List<T> findAll();
+
+    T save(T entity);
+
+    void deleteById(Long id);
+
+    void deleteAll();
+
+}

--- a/src/main/java/com/seals/camplanner/event/services/EventService.java
+++ b/src/main/java/com/seals/camplanner/event/services/EventService.java
@@ -26,7 +26,7 @@ public class EventService {
         newEvent.setEventDate(event.getEventDate());
         newEvent.setStarts(event.getStarts());
         newEvent.setEnds(event.getEnds());
-        Location location = locationService.find(event.getLocation());
+        Location location = locationService.findById(event.getLocation());
         newEvent.setLocation(location);
         return eventRepository.save(newEvent);
     }

--- a/src/main/java/com/seals/camplanner/location/controllers/LocationController.java
+++ b/src/main/java/com/seals/camplanner/location/controllers/LocationController.java
@@ -24,7 +24,7 @@ public class LocationController {
 
     @GetMapping("/location/{id}")
     public Location getLocation(@PathVariable("id") Long id) {
-        return locationService.find(id);
+        return locationService.findById(id);
     }
 
     @DeleteMapping("/location/{id}")

--- a/src/main/java/com/seals/camplanner/location/models/Location.java
+++ b/src/main/java/com/seals/camplanner/location/models/Location.java
@@ -1,16 +1,15 @@
 package com.seals.camplanner.location.models;
 
+import com.seals.camplanner.commons.models.BaseEntity;
 import lombok.Data;
 
 import javax.persistence.*;
+import lombok.EqualsAndHashCode;
 
 @Entity
 @Data
-public class Location {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@EqualsAndHashCode(callSuper = true)
+public class Location extends BaseEntity {
 
     @Column(name = "name", nullable = false, unique = true)
     private String name;

--- a/src/main/java/com/seals/camplanner/location/services/LocationService.java
+++ b/src/main/java/com/seals/camplanner/location/services/LocationService.java
@@ -1,35 +1,27 @@
 package com.seals.camplanner.location.services;
 
+import com.seals.camplanner.commons.services.BaseService;
 import com.seals.camplanner.location.models.Location;
 import com.seals.camplanner.location.repositories.LocationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class LocationService {
+public class LocationService extends BaseService<Location> {
+
+    private static final String ENTITY_NAME = "Location";
+
     private final LocationRepository locationRepository;
 
-    public List<Location> findAll() {
-        return locationRepository.findAll();
+    @Override
+    protected JpaRepository<Location, Long> getRepository() {
+        return this.locationRepository;
     }
 
-    public Location save(Location location) {
-        return locationRepository.save(location);
-    }
-
-    //TODO create customized exeption
-    public Location find(Long id) {
-        return locationRepository.findById(id).orElseThrow(() -> new RuntimeException("Location not found"));
-    }
-
-    public void deleteById(Long id) {
-        locationRepository.deleteById(id);
-    }
-
-    public void deleteAll() {
-        locationRepository.deleteAll();
+    @Override
+    public String getEntityName() {
+        return ENTITY_NAME;
     }
 }

--- a/src/test/java/com/seals/camplanner/commons/services/ServiceTestBase.java
+++ b/src/test/java/com/seals/camplanner/commons/services/ServiceTestBase.java
@@ -1,0 +1,90 @@
+package com.seals.camplanner.commons.services;
+
+import com.seals.camplanner.commons.models.BaseEntity;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Random;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public abstract class ServiceTestBase<T extends BaseEntity> {
+
+    public static final Random RANDOM = new Random();
+
+    protected abstract BaseService<T> getService();
+
+    protected abstract JpaRepository<T, Long> getRepositoryMock();
+
+    protected abstract T getSample();
+
+    @Test
+    public void findByIdTest() {
+        T expected = this.getSample();
+        Long id = expected.getId();
+        Mockito.when(this.getRepositoryMock().findById(id)).thenReturn(Optional.of(expected));
+        T actual = this.getService().findById(id);
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void findByIdNotFoundTest() {
+        Long id = RANDOM.nextLong();
+        Mockito.when(this.getRepositoryMock().findById(id)).thenReturn(Optional.empty());
+        Assertions.assertThrows(NoSuchElementException.class, () -> this.getService().findById(id));
+    }
+
+    @Test
+    public void findAllTest() {
+        T location1 = this.getSample();
+        T location2 = this.getSample();
+        T location3 = this.getSample();
+        List<T> expected = List.of(location1, location2, location3);
+        Mockito.when(this.getRepositoryMock().findAll()).thenReturn(expected);
+        List<T> actual = this.getService().findAll();
+        Assertions.assertEquals(expected.size(), actual.size());
+        Assertions.assertTrue(actual.containsAll(expected));
+    }
+
+    @Test
+    public void findAllEmptyTest() {
+        List<T> expected = List.of();
+        Mockito.when(this.getRepositoryMock().findAll()).thenReturn(expected);
+        List<T> actual = this.getService().findAll();
+        Assertions.assertEquals(0, actual.size());
+    }
+
+    @Test
+    public void saveTest() {
+        T toSave = this.getSample();
+        toSave.setId(null);
+        long newId = RANDOM.nextLong();
+        Mockito.when(this.getRepositoryMock().save(toSave)).thenAnswer(invocation -> {
+            T saved = this.getSample();
+            BeanUtils.copyProperties(toSave, saved);
+            saved.setId(newId);
+            return saved;
+        });
+        T saved = this.getService().save(toSave);
+        Mockito.verify(this.getRepositoryMock()).save(toSave);
+        Assertions.assertEquals(newId, saved.getId());
+        toSave.setId(newId);
+        Assertions.assertEquals(toSave, saved);
+    }
+
+    @Test
+    public void deleteByIdTest() {
+        Long idToDelete = RANDOM.nextLong();
+        this.getService().deleteById(idToDelete);
+        Mockito.verify(this.getRepositoryMock()).deleteById(idToDelete);
+    }
+
+    @Test
+    public void deleteAllTest() {
+        this.getService().deleteAll();
+        Mockito.verify(this.getRepositoryMock()).deleteAll();
+    }
+}

--- a/src/test/java/com/seals/camplanner/location/services/LocationServiceTest.java
+++ b/src/test/java/com/seals/camplanner/location/services/LocationServiceTest.java
@@ -1,18 +1,15 @@
 package com.seals.camplanner.location.services;
 
+import com.seals.camplanner.commons.services.BaseService;
+import com.seals.camplanner.commons.services.ServiceTestBase;
 import com.seals.camplanner.location.models.Location;
 import com.seals.camplanner.location.repositories.LocationRepository;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
 import java.util.UUID;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Unit tests for the Location Service.
@@ -21,85 +18,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * here. The repository is mocked so there will be no interactions with the database.</p>
  */
 @ExtendWith(MockitoExtension.class)
-public class LocationServiceTest {
-
-    public static final Random RANDOM = new Random();
+public class LocationServiceTest extends ServiceTestBase<Location> {
 
     @Mock
     private LocationRepository locationRepository;
     @InjectMocks
     private LocationService locationService;
 
-    @Test
-    public void findByIdTest() {
-        Location expected = this.getSampleLocation();
-        Long id = expected.getId();
-        Mockito.when(this.locationRepository.findById(id)).thenReturn(Optional.of(expected));
-        Location actual = this.locationService.find(id);
-        Assertions.assertEquals(expected, actual);
+    @Override
+    protected BaseService<Location> getService() {
+        return this.locationService;
     }
 
-    @Test
-    public void findByIdNotFoundTest() {
-        Long id = RANDOM.nextLong();
-        Mockito.when(this.locationRepository.findById(id)).thenReturn(Optional.empty());
-        Assertions.assertThrows(RuntimeException.class, () -> this.locationService.find(id));
+    @Override
+    protected JpaRepository<Location, Long> getRepositoryMock() {
+        return this.locationRepository;
     }
 
-    @Test
-    public void findAllTest() {
-        Location location1 = this.getSampleLocation();
-        Location location2 = this.getSampleLocation();
-        Location location3 = this.getSampleLocation();
-        List<Location> expected = List.of(location1, location2, location3);
-        Mockito.when(this.locationRepository.findAll()).thenReturn(expected);
-        List<Location> actual = this.locationService.findAll();
-        Assertions.assertEquals(expected.size(), actual.size());
-        Assertions.assertTrue(actual.containsAll(expected));
-    }
-
-    @Test
-    public void findAllEmptyTest() {
-        List<Location> expected = List.of();
-        Mockito.when(this.locationRepository.findAll()).thenReturn(expected);
-        List<Location> actual = this.locationService.findAll();
-        Assertions.assertEquals(0, actual.size());
-    }
-
-    @Test
-    public void saveTest() {
-        Location toSave = this.getSampleLocation();
-        toSave.setId(null);
-        Mockito.when(this.locationRepository.save(toSave)).thenAnswer(invocation -> {
-            Location saved = new Location();
-            saved.setId(RANDOM.nextLong());
-            saved.setName(toSave.getName());
-            saved.setCountry(toSave.getCountry());
-            saved.setCity(toSave.getCity());
-            return saved;
-        });
-        Location saved = this.locationService.save(toSave);
-        Mockito.verify(this.locationRepository).save(toSave);
-        Assertions.assertNotNull(saved.getId());
-        Assertions.assertEquals(toSave.getName(), saved.getName());
-        Assertions.assertEquals(toSave.getCountry(), saved.getCountry());
-        Assertions.assertEquals(toSave.getCity(), saved.getCity());
-    }
-
-    @Test
-    public void deleteByIdTest() {
-        Long idToDelete = RANDOM.nextLong();
-        this.locationService.deleteById(idToDelete);
-        Mockito.verify(this.locationRepository).deleteById(idToDelete);
-    }
-
-    @Test
-    public void deleteAllTest() {
-        this.locationService.deleteAll();
-        Mockito.verify(this.locationRepository).deleteAll();
-    }
-
-    public Location getSampleLocation() {
+    @Override
+    protected Location getSample() {
         Location sampleLocation = new Location();
         sampleLocation.setId(RANDOM.nextLong());
         sampleLocation.setCity(UUID.randomUUID().toString());


### PR DESCRIPTION
The Base classes focuses on providing a sensible default for simple CRUD Services, providing methods to find, delete, save, and more to come. My reasoning is that using them will ensure that method naming and behaviors remain consistent across services.

There is also a ServiceTestBase class that when extended provides default tests for all provided methods on the BaseService for your entity.