### PR TITLE
#9 Add tests to EventService

### DIFF
--- a/src/main/java/com/seals/camplanner/event/controllers/EventController.java
+++ b/src/main/java/com/seals/camplanner/event/controllers/EventController.java
@@ -1,5 +1,6 @@
 package com.seals.camplanner.event.controllers;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.seals.camplanner.event.dto.EventDto;
 import com.seals.camplanner.event.models.Event;
 import com.seals.camplanner.event.services.EventService;
@@ -10,6 +11,7 @@ import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.*;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 @RestController
@@ -43,12 +45,12 @@ public class EventController {
 
     @GetMapping("/event/{id}")
     public EventDto getEvent(@PathVariable("id") Long id) {
-        return toDto(eventService.find(id));
+        return toDto(eventService.findById(id));
     }
 
     @DeleteMapping("/event/{id}")
     public void deleteEvent(@PathVariable("id") Long id) {
-        eventService.delete(id);
+        eventService.deleteById(id);
     }
 
     private EventDto toDto(Event event) {
@@ -60,6 +62,8 @@ public class EventController {
     }
 
     private List<EventDto> toEventDtoList(List<Event> events) {
-        return events.stream().map(event -> modelMapper.map(event, EventDto.class)).toList();
+        Type type = new TypeReference<List<EventDto>>() {
+        }.getType();
+        return modelMapper.map(events, type);
     }
 }

--- a/src/main/java/com/seals/camplanner/event/models/Event.java
+++ b/src/main/java/com/seals/camplanner/event/models/Event.java
@@ -1,18 +1,20 @@
 package com.seals.camplanner.event.models;
 
+import com.seals.camplanner.commons.models.BaseEntity;
 import com.seals.camplanner.location.models.Location;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.sql.Timestamp;
 
 @Entity
 @Data
-public class Event {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@EqualsAndHashCode(callSuper = true)
+public class Event extends BaseEntity {
 
     @Column(name = "private_event", nullable = false)
     private boolean privateEvent;
@@ -26,7 +28,8 @@ public class Event {
     @Column(name = "ends", nullable = false)
     private Timestamp ends;
 
-    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "location_id", nullable = false)
     private Location location;
 }
+

--- a/src/main/java/com/seals/camplanner/event/services/EventService.java
+++ b/src/main/java/com/seals/camplanner/event/services/EventService.java
@@ -1,31 +1,25 @@
 package com.seals.camplanner.event.services;
 
+import com.seals.camplanner.commons.services.BaseServiceImpl;
 import com.seals.camplanner.event.models.Event;
 import com.seals.camplanner.event.repositories.EventRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class EventService {
+public class EventService extends BaseServiceImpl<Event> {
+    public static final String ENTITY_NAME = "Event";
     private final EventRepository eventRepository;
 
-    public List<Event> findAll() {
-        return eventRepository.findAll();
+    @Override
+    protected JpaRepository<Event, Long> getRepository() {
+        return this.eventRepository;
     }
 
-    public Event save(Event event) {
-        return eventRepository.save(event);
-    }
-
-    //TODO create customized exeption
-    public Event find(Long id) {
-        return eventRepository.findById(id).orElseThrow(() -> new RuntimeException("Event not found"));
-    }
-
-    public void delete(Long id) {
-        eventRepository.deleteById(id);
+    @Override
+    public String getEntityName() {
+        return ENTITY_NAME;
     }
 }

--- a/src/test/java/com/seals/camplanner/commons/services/TestUtils.java
+++ b/src/test/java/com/seals/camplanner/commons/services/TestUtils.java
@@ -1,0 +1,12 @@
+package com.seals.camplanner.commons.services;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.Random;
+
+@UtilityClass
+public class TestUtils {
+
+    public static final Random RANDOM = new Random();
+
+}

--- a/src/test/java/com/seals/camplanner/event/EventTestUtils.java
+++ b/src/test/java/com/seals/camplanner/event/EventTestUtils.java
@@ -1,0 +1,25 @@
+package com.seals.camplanner.event;
+
+import com.seals.camplanner.location.LocationTestUtils;
+import com.seals.camplanner.event.models.Event;
+import lombok.experimental.UtilityClass;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@UtilityClass
+public class EventTestUtils {
+
+    public static Event getSampleEvent() {
+        Event event = new Event();
+        Instant now = Instant.now();
+        Timestamp starts = Timestamp.from(now);
+        Timestamp ends = Timestamp.from(now.plus(2, ChronoUnit.DAYS));
+        event.setEventDate(starts);
+        event.setStarts(starts);
+        event.setEnds(ends);
+        event.setLocation(LocationTestUtils.getSampleLocation());
+        return event;
+    }
+}

--- a/src/test/java/com/seals/camplanner/event/controllers/EventControllerTest.java
+++ b/src/test/java/com/seals/camplanner/event/controllers/EventControllerTest.java
@@ -1,15 +1,11 @@
 package com.seals.camplanner.event.controllers;
 
-import com.seals.camplanner.commons.TestUtils;
+import com.seals.camplanner.event.EventTestUtils;
 import com.seals.camplanner.event.dto.EventDto;
 import com.seals.camplanner.event.models.Event;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
-
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 class EventControllerTest {
 
@@ -17,7 +13,7 @@ class EventControllerTest {
 
     @Test
     void shouldMatchValuesMappingEventEventDto() {
-        Event event = getSampleEvent();
+        Event event = EventTestUtils.getSampleEvent();
         EventDto eventDto = modelMapper.map(event, EventDto.class);
 
         Assertions.assertEquals(event.getId(), eventDto.getId());
@@ -25,18 +21,6 @@ class EventControllerTest {
         Assertions.assertEquals(event.getStarts(), eventDto.getStarts());
         Assertions.assertEquals(event.getEnds(), eventDto.getEnds());
         Assertions.assertEquals(event.getLocation().getId(), eventDto.getLocationId());
-    }
-
-    private Event getSampleEvent() {
-        Event event = new Event();
-        Instant now = Instant.now();
-        Timestamp starts = Timestamp.from(now);
-        Timestamp ends = Timestamp.from(now.plus(2, ChronoUnit.DAYS));
-        event.setEventDate(starts);
-        event.setStarts(starts);
-        event.setEnds(ends);
-        event.setLocation(TestUtils.getSampleLocation());
-        return event;
     }
 
     //TODO create test from EventDto to Event

--- a/src/test/java/com/seals/camplanner/event/services/EventServiceTest.java
+++ b/src/test/java/com/seals/camplanner/event/services/EventServiceTest.java
@@ -1,0 +1,36 @@
+package com.seals.camplanner.event.services;
+
+import com.seals.camplanner.commons.services.BaseServiceImpl;
+import com.seals.camplanner.commons.services.ServiceTestBase;
+import com.seals.camplanner.event.EventTestUtils;
+import com.seals.camplanner.event.models.Event;
+import com.seals.camplanner.event.repositories.EventRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class EventServiceTest extends ServiceTestBase<Event> {
+
+    @Mock
+    private EventRepository repository;
+    @InjectMocks
+    private EventService eventService;
+
+    @Override
+    protected BaseServiceImpl<Event> getService() {
+        return this.eventService;
+    }
+
+    @Override
+    protected JpaRepository<Event, Long> getRepositoryMock() {
+        return this.repository;
+    }
+
+    @Override
+    protected Event getSample() {
+        return EventTestUtils.getSampleEvent();
+    }
+}

--- a/src/test/java/com/seals/camplanner/location/LocationTestUtils.java
+++ b/src/test/java/com/seals/camplanner/location/LocationTestUtils.java
@@ -1,19 +1,18 @@
-package com.seals.camplanner.commons;
+package com.seals.camplanner.location;
 
+import com.seals.camplanner.commons.services.TestUtils;
 import com.seals.camplanner.location.dto.LocationDto;
 import com.seals.camplanner.location.models.Location;
 import lombok.experimental.UtilityClass;
 
-import java.util.Random;
 import java.util.UUID;
 
 @UtilityClass
-public final class TestUtils {
-    public static final Random RANDOM = new Random();
+public final class LocationTestUtils {
 
     public static Location getSampleLocation() {
         Location location = new Location();
-        location.setId(RANDOM.nextLong());
+        location.setId(TestUtils.RANDOM.nextLong());
         location.setName(UUID.randomUUID().toString());
         location.setCity(UUID.randomUUID().toString());
         location.setCountry(UUID.randomUUID().toString());
@@ -22,7 +21,7 @@ public final class TestUtils {
 
     public static LocationDto getSampleLocationDto() {
         LocationDto locationDto = new LocationDto();
-        locationDto.setId(RANDOM.nextLong());
+        locationDto.setId(TestUtils.RANDOM.nextLong());
         locationDto.setName(UUID.randomUUID().toString());
         locationDto.setCity(UUID.randomUUID().toString());
         locationDto.setCountry(UUID.randomUUID().toString());

--- a/src/test/java/com/seals/camplanner/location/controllers/LocationControllerTest.java
+++ b/src/test/java/com/seals/camplanner/location/controllers/LocationControllerTest.java
@@ -2,7 +2,7 @@ package com.seals.camplanner.location.controllers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.seals.camplanner.commons.TestUtils;
+import com.seals.camplanner.location.LocationTestUtils;
 import com.seals.camplanner.location.dto.LocationDto;
 import com.seals.camplanner.location.models.Location;
 import com.seals.camplanner.location.services.LocationService;
@@ -58,7 +58,7 @@ class LocationControllerTest {
 
     @Test
     void saveLocationTest() throws Exception {
-        Location location = TestUtils.getSampleLocation();
+        Location location = LocationTestUtils.getSampleLocation();
 
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post("/location")
                                                                       .contentType(MediaType.APPLICATION_JSON)
@@ -76,9 +76,9 @@ class LocationControllerTest {
     @Test
     void findAllTest() throws Exception {
         List<Location> expected = new ArrayList<>();
-        expected.add(this.locationService.save(TestUtils.getSampleLocation()));
-        expected.add(this.locationService.save(TestUtils.getSampleLocation()));
-        expected.add(this.locationService.save(TestUtils.getSampleLocation()));
+        expected.add(this.locationService.save(LocationTestUtils.getSampleLocation()));
+        expected.add(this.locationService.save(LocationTestUtils.getSampleLocation()));
+        expected.add(this.locationService.save(LocationTestUtils.getSampleLocation()));
 
         MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders.get("/location"))
                                        .andExpect(MockMvcResultMatchers.status().isOk())
@@ -95,7 +95,7 @@ class LocationControllerTest {
 
     @Test
     void findByIdTest() throws Exception {
-        Location expected = this.locationService.save(TestUtils.getSampleLocation());
+        Location expected = this.locationService.save(LocationTestUtils.getSampleLocation());
 
         MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders.get("/location/{id}", expected.getId()))
                                        .andExpect(MockMvcResultMatchers.status().isOk())
@@ -108,7 +108,7 @@ class LocationControllerTest {
 
     @Test
     void deleteByIdTest() throws Exception {
-        Location location = this.locationService.save(TestUtils.getSampleLocation());
+        Location location = this.locationService.save(LocationTestUtils.getSampleLocation());
 
         this.mockMvc.perform(MockMvcRequestBuilders.delete("/location/{id}", location.getId()))
                     .andExpect(MockMvcResultMatchers.status().isOk());
@@ -117,7 +117,7 @@ class LocationControllerTest {
 
     @Test
     void shouldMatchValuesMappingLocationToLocationDto() {
-        Location location = TestUtils.getSampleLocation();
+        Location location = LocationTestUtils.getSampleLocation();
         LocationDto locationDto = modelMapper.map(location, LocationDto.class);
 
         Assertions.assertEquals(location.getId(), locationDto.getId());
@@ -128,7 +128,7 @@ class LocationControllerTest {
 
     @Test
     void shouldMatchValuesMappingLocationDtoToLocation() {
-        LocationDto locationDto = TestUtils.getSampleLocationDto();
+        LocationDto locationDto = LocationTestUtils.getSampleLocationDto();
         Location location =  modelMapper.map(locationDto, Location.class);
 
         Assertions.assertEquals(locationDto.getId(), location.getId());


### PR DESCRIPTION
This PR implements the first part of #9, adding tests to the Event Service.

Changed `Event` to extend `BaseEntity` allowing the use of `BaseService`
Changed `EventService` to extend `BaseService`, allowing the use of ServiceTestBase
Created the `EventServiceTest` to apply `ServiceTestBase` tests

Also Reorganized some Test classes